### PR TITLE
スクレイピングをすべて selenium で行うように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # asp_reader_lambda
 ## Python version
-Only 2.x
+3.x
 
 ## What's this?
 This service searches ASP data.
@@ -9,32 +9,4 @@ This service searches ASP data.
 2. Send data to your LINE.
 
 ## How to use?
-### 1. Write your personal data on `line_notify.yml` and `security.yml`
-#### line_notify.yml
-Duplicate this file from `line_notify.yml.sample`.
-If you write your LINE token, it's enbale to send data to LINE.
-[LINE Notify](https://notify-bot.line.me/) provides LINE token.
-
-#### security.yml
-Duplicate this file from `line_notify.yml.sample`.
-If you write your personal ASP data, it's enbale to search data.
-
-### 2. Install libraries
-
-```
-$ pip install -r requirements
-```
-
-### 3. Execute code
-
-```
-$ python main.py
-```
-
-The data outputs to data.csv, and send data to LINE.
-
-## Schedule LINE Notify
-1. Write `line_notify.yml` and `security.yml`.
-2. `pip install -r requirements -t .`
-3. Zip all files, not folder.
-4. Upload the zip file to AWS Lambda, and set schedule by CloudWatch Events.
+check the [note](https://note.mu/mc_chinju/n/ncb9ad6965aaf)!

--- a/asp.yml
+++ b/asp.yml
@@ -14,8 +14,8 @@ mosimo:
   login: https://af.moshimo.com/af/shop/login
   data: https://af.moshimo.com/af/shop/report/payment
 presco:
-  login: https://presco.asia/index/login
-  data: https://presco.asia/partneradmin/report
+  login: https://presco.ai
+  data: https://presco.ai/partner/actionLog/list
 rentracks:
   login: https://manage.rentracks.jp/manage/login
   data: https://manage.rentracks.jp/manage/top

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -213,30 +213,24 @@ def search_asps():
         #     except:
         #         add_line_message(asp_name, "取得失敗")
 
-        elif asp_name == "presco":
-            try:
-                # Login
-                driver.get(login_page)
-                driver.find_element_by_name("loginId").send_keys(login_id)
-                driver.find_element_by_name("password").send_keys(password)
-                driver.find_element_by_id("button1").click()
-
-                now = datetime.datetime.now()
-                year = str(now.year)
-                month = str(now.month)
-                if (len(month) == 1):
-                    month = "0" + month
-                latest_data_page = ("%s/daily/yyyymm/%s-%s/" % (data_page, year, month))
-                driver.get(latest_data_page)
-
-                html = driver.page_source.encode("utf-8")
-                soup = BeautifulSoup(html, "html.parser")
-
-                target = soup.select("#mainContents tbody tr")[now.day + 1]
-                price = to_num_s(target.find_all("td")[-1].text)
-                add_line_message(asp_name, delimited(price))
-            except:
-                add_line_message(asp_name, "取得失敗")
+        # TODO: 売上がゼロのためhtml構造がわからず結果の出力ができない
+        # elif asp_name == "presco":
+        #     try:
+        #         # Login
+        #         driver.get(login_page)
+        #         driver.find_elements_by_xpath("//input[@name='username']")[1].send_keys(login_id)
+        #         driver.find_elements_by_xpath("//input[@name='password']")[1].send_keys(password)
+        #         driver.find_elements_by_xpath("//input[@type='submit']")[1].click()
+        #
+        #         driver.get(data_page)
+        #         html = driver.page_source.encode("utf-8")
+        #         soup = BeautifulSoup(html, "html.parser")
+        #
+        #         # target = soup.select("#mainContents tbody tr")[now.day + 1]
+        #         # price = to_num_s(target.find_all("td")[-1].text)
+        #         add_line_message(asp_name, delimited(price))
+        #     except:
+        #         add_line_message(asp_name, "取得失敗")
 
 def line_notify():
     # LINE Notify settings

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -95,13 +95,13 @@ def search_asps():
 
         elif asp_name == "felmat":
             try:
-                agent.open(login_page)
-                agent.select_form(name="loginForm")
-                agent["p_username"] = login_id
-                agent["p_password"] = password
-                agent.submit()
+                driver.get(login_page)
+                driver.find_element_by_name("p_username").send_keys(login_id)
+                driver.find_element_by_name("p_password").send_keys(password)
+                driver.find_element_by_name("partnerlogin").click()
 
-                html = agent.open("%s/%s" % (data_page, "daily"))
+                time.sleep(3) # js読み込みが終わるまでのバッファ
+                html = driver.page_source.encode("utf-8")
                 soup = BeautifulSoup(html, "html.parser")
 
                 today_number = datetime.date.today().day
@@ -113,14 +113,13 @@ def search_asps():
 
         elif asp_name == "access_trade":
             try:
-                agent.open(login_page)
-                form_action = "https://member.accesstrade.net/atv3/login.html"
-                agent.select_form(action=form_action)
-                agent["userId"] = login_id
-                agent["userPass"] = password
-                agent.submit()
+                driver.get(login_page)
+                driver.find_element_by_name("userId").send_keys(login_id)
+                driver.find_element_by_name("userPass").send_keys(password)
+                driver.find_element_by_xpath("//form[@action='https://member.accesstrade.net/atv3/login.html']/input[@class='btn']").click()
 
-                html = agent.open(data_page)
+                time.sleep(3) # js読み込みが終わるまでのバッファ
+                html = driver.page_source.encode("utf-8")
                 soup = BeautifulSoup(html, "html.parser")
                 target = soup.select(".report tbody tr")
                 price = to_num_s(target[2].find_all("td")[0].text)

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,5 +1,6 @@
 # coding: UTF-8
 
+import os
 import re
 import time
 import requests
@@ -22,21 +23,24 @@ chrome_options.add_argument("--no-sandbox")
 chrome_options.add_argument("--single-process")
 driver_path = "./bin/chromedriver"
 driver = webdriver.Chrome(driver_path, chrome_options=chrome_options)
-driver = webdriver.Chrome()
 
 with open("asp.yml", "r") as file:
     asp_info = yaml.safe_load(file.read())
 
 # Securities settings
 asp_names = list()
-with open("security.yml", "r") as file:
-    security_info = yaml.safe_load(file.read())
-    # TODO: refactoring code!
-    # Select target asps
-    _asp_names = security_info.keys()
-    for asp_name in _asp_names:
-        if security_info[asp_name]["id"]:
-            asp_names.append(asp_name)
+for k, v, in os.environ.items():
+    if (("ASP_ID" in k) and (len(v) != 0)):
+        asp_name = k.split("ASP_ID_")[1].lower()
+        asp_names.append(asp_name)
+
+# for development
+# asp_names = list()
+# with open("security.yml", "r") as file:
+#     security_info = yaml.safe_load(file.read())
+#     for asp_name in security_info.keys():
+#         if security_info[asp_name]["id"]:
+#             asp_names.append(asp_name)
 
 # For instance_variable_set
 class Container():
@@ -65,8 +69,11 @@ def search_asps():
     for asp_name in asp_names:
         login_page = asp_info[asp_name]["login"]
         data_page = asp_info[asp_name]["data"]
-        login_id = security_info[asp_name]["id"]
-        password = security_info[asp_name]["password"]
+        # for development
+        # login_id = security_info[asp_name]["id"]
+        # password = security_info[asp_name]["password"]
+        login_id = os.environ[f"ASP_ID_{asp_name.upper()}"]
+        password = os.environ[f"ASP_PW_{asp_name.upper()}"]
 
         print("%sのデータ検索を開始します。" % camelize(asp_name))
         if asp_name == "a8":
@@ -233,9 +240,13 @@ def search_asps():
 
 def line_notify():
     # LINE Notify settings
-    with open("line_notify.yml", "r") as file:
-        line_pay = file.read()
-    LINE_TOKEN = yaml.safe_load(line_pay)["token"]
+
+    # for development
+    # with open("line_notify.yml", "r") as file:
+    #     line_notify = file.read()
+    # LINE_TOKEN = yaml.safe_load(line_notify)["token"]
+
+    LINE_TOKEN = os.environ["LINE_NOTIFY_TOKEN"]
     LINE_NOTIFY_URL = "https://notify-api.line.me/api/notify"
 
     # LINe Notify logic
@@ -250,12 +261,6 @@ def line_notify():
             print(sys.exc_info())
 
 def lambda_handler(event, context):
-    initialize()
-    search_asps()
-    line_notify()
-
-
-if __name__ == '__main__':
     initialize()
     search_asps()
     line_notify()

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -41,7 +41,6 @@ with open("security.yml", "r") as file:
     # TODO: refactoring code!
     # Select target asps
     _asp_names = security_info.keys()
-    _asp_names.sort()
     for asp_name in _asp_names:
         if security_info[asp_name]["id"]:
             asp_names.append(asp_name)
@@ -57,7 +56,7 @@ def initialize():
     c.line_notify_message = "本日の発生報酬"
 
 def to_num_s(str):
-    return re.sub(r"\D", "", str.strip().encode("utf-8"))
+    return re.sub(r"\D", "", str.strip())
 
 def delimited(str):
     return "¥{:,d}".format(int(str))
@@ -100,6 +99,7 @@ def search_asps():
                 driver.find_element_by_name("p_password").send_keys(password)
                 driver.find_element_by_name("partnerlogin").click()
 
+                driver.get(f"{data_page}/daily")
                 time.sleep(3) # js読み込みが終わるまでのバッファ
                 html = driver.page_source.encode("utf-8")
                 soup = BeautifulSoup(html, "html.parser")

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -11,8 +11,8 @@ from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.action_chains import ActionChains
 
-from IPython import embed
-from IPython.terminal.embed import InteractiveShellEmbed
+# from IPython import embed
+# from IPython.terminal.embed import InteractiveShellEmbed
 
 ## Chrome Headless Browser
 chrome_options = Options()

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -62,7 +62,6 @@ def add_line_message(asp_name, message):
     c.line_notify_message += "\n" + camelize(asp_name) + ": " + message
 
 def search_asps():
-    asp_names = ["mosimo"]
     for asp_name in asp_names:
         login_page = asp_info[asp_name]["login"]
         data_page = asp_info[asp_name]["data"]
@@ -81,7 +80,6 @@ def search_asps():
                 html = driver.page_source.encode("utf-8")
                 soup = BeautifulSoup(html, "html.parser")
                 target = soup.select("#reportBox01 .repo03 td")
-                embed()
                 price = to_num_s(target[0].text)
                 add_line_message(asp_name, delimited(price))
             except:
@@ -142,14 +140,15 @@ def search_asps():
 
         elif asp_name == "rentracks":
             try:
-                agent.open(login_page)
-                form_action = "https://manage.rentracks.jp/manage/login/login_manage_validation"
-                agent.select_form(action=form_action)
-                agent["idMailaddress"] = login_id
-                agent["idLoginPassword"] = password
-                agent.submit()
+                driver.get(login_page)
+                driver.find_element_by_name("idMailaddress").send_keys(login_id)
+                driver.find_element_by_name("idLoginPassword").send_keys(password)
+                driver.find_element_by_name("idButton").click()
 
-                html = agent.open(data_page)
+                driver.get(data_page)
+                time.sleep(3) # js読み込みが終わるまでのバッファ
+
+                html = driver.page_source.encode("utf-8")
                 soup = BeautifulSoup(html, "html.parser")
                 target = soup.select(".datatable tr")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 beautifulsoup4==4.6.0
-mechanize==0.3.6
 requests==2.21.0
 pyyaml>=4.2b1
 selenium==3.13.0


### PR DESCRIPTION
## 背景
 - 今まで静的ページは、書きやすさから mechanize を使用していたが、python 2.x でしか提供されていなかった。
 - python 2.x は、2020年2月くらいでサポートが切れるため、3.x で動作するように更新が必要であった。

## 対応
 - mechanize の使用をとりやめ、すべて selenium でスクレイピングを実行するように修正
 - ユーザー設定を yml で行うようにしていたのを、Lambda の環境変数を使用するように修正
